### PR TITLE
add: cmake_modules dependency according to Catkin Indigo migration guide

### DIFF
--- a/camera_handler/CMakeLists.txt
+++ b/camera_handler/CMakeLists.txt
@@ -8,9 +8,11 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   sensor_msgs
   image_transport
+  cmake_modules
   vrep_ros_plugin
 )
 
+find_package(cmake_modules REQUIRED)
 find_package(Eigen REQUIRED)
 
 ## System dependencies are found with CMake's conventions

--- a/camera_handler/package.xml
+++ b/camera_handler/package.xml
@@ -38,6 +38,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>image_transport</build_depend>
+  <build_depend>cmake_modules</build_depend>
   <build_depend>vrep_ros_plugin</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>

--- a/force_sensor_handler/CMakeLists.txt
+++ b/force_sensor_handler/CMakeLists.txt
@@ -7,10 +7,12 @@ project(force_sensor_handler)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   geometry_msgs
+  cmake_modules
   vrep_ros_plugin
   
 )
 
+find_package(cmake_modules REQUIRED)
 find_package(Eigen REQUIRED)
 
 ## System dependencies are found with CMake's conventions

--- a/force_sensor_handler/package.xml
+++ b/force_sensor_handler/package.xml
@@ -19,6 +19,7 @@
 
   <build_depend>roscpp</build_depend>
   <build_depend>geometry_msgs</build_depend>
+  <build_depend>cmake_modules</build_depend>
   <build_depend>vrep_ros_plugin</build_depend>
   <!--<build_depend>telekyb_base</build_depend>-->
 

--- a/imu_handler/CMakeLists.txt
+++ b/imu_handler/CMakeLists.txt
@@ -7,10 +7,12 @@ project(imu_handler)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   sensor_msgs
+  cmake_modules
   vrep_ros_plugin
   ##telekyb_base
 )
 
+find_package(cmake_modules REQUIRED)
 find_package(Eigen REQUIRED)
 
 ## System dependencies are found with CMake's conventions

--- a/imu_handler/package.xml
+++ b/imu_handler/package.xml
@@ -19,6 +19,7 @@
 
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>cmake_modules</build_depend>
   <build_depend>vrep_ros_plugin</build_depend>
   <!--<build_depend>telekyb_base</build_depend>-->
 

--- a/manipulator_handler/CMakeLists.txt
+++ b/manipulator_handler/CMakeLists.txt
@@ -7,9 +7,11 @@ project(manipulator_handler)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   sensor_msgs
+  cmake_modules
   vrep_ros_plugin
 )
 
+find_package(cmake_modules REQUIRED)
 find_package(Eigen REQUIRED)
 
 ## System dependencies are found with CMake's conventions

--- a/manipulator_handler/package.xml
+++ b/manipulator_handler/package.xml
@@ -20,6 +20,7 @@
 
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>cmake_modules</build_depend>
   <build_depend>vrep_ros_plugin</build_depend>
   
   <run_depend>roscpp</run_depend>

--- a/quadrotor_handler/CMakeLists.txt
+++ b/quadrotor_handler/CMakeLists.txt
@@ -8,9 +8,11 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   sensor_msgs
   geometry_msgs
+  cmake_modules
   vrep_ros_plugin
 )
 
+find_package(cmake_modules REQUIRED)
 find_package(Eigen REQUIRED)
 
 ## System dependencies are found with CMake's conventions

--- a/quadrotor_handler/package.xml
+++ b/quadrotor_handler/package.xml
@@ -21,6 +21,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
+  <build_depend>cmake_modules</build_depend>
   <build_depend>vrep_ros_plugin</build_depend>
 
   <run_depend>roscpp</run_depend>

--- a/quadrotor_tk_handler/CMakeLists.txt
+++ b/quadrotor_tk_handler/CMakeLists.txt
@@ -8,9 +8,11 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   sensor_msgs
   telekyb_msgs
+  cmake_modules
   vrep_ros_plugin
 )
 
+find_package(cmake_modules REQUIRED)
 find_package(Eigen REQUIRED)
 
 ## System dependencies are found with CMake's conventions

--- a/quadrotor_tk_handler/package.xml
+++ b/quadrotor_tk_handler/package.xml
@@ -43,6 +43,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>telekyb_msgs</build_depend>
+  <build_depend>cmake_modules</build_depend>
   <build_depend>vrep_ros_plugin</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>

--- a/rigid_body_handler/CMakeLists.txt
+++ b/rigid_body_handler/CMakeLists.txt
@@ -7,9 +7,11 @@ project(rigid_body_handler)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   geometry_msgs
+  cmake_modules
   vrep_ros_plugin
 )
 
+find_package(cmake_modules REQUIRED)
 find_package(Eigen REQUIRED)
 
 ## System dependencies are found with CMake's conventions

--- a/rigid_body_handler/package.xml
+++ b/rigid_body_handler/package.xml
@@ -23,6 +23,7 @@
   
   <build_depend>roscpp</build_depend>
   <build_depend>geometry_msgs</build_depend>
+  <build_depend>cmake_modules</build_depend>
   <build_depend>vrep_ros_plugin</build_depend>
   
   <run_depend>roscpp</run_depend>

--- a/vrep_ros_plugin/CMakeLists.txt
+++ b/vrep_ros_plugin/CMakeLists.txt
@@ -17,9 +17,11 @@ endif()
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   pluginlib
+  cmake_modules
 )
 
 ## System dependencies are found with CMake's conventions
+find_package(cmake_modules REQUIRED)
 find_package(Eigen REQUIRED)
 
 

--- a/vrep_ros_plugin/package.xml
+++ b/vrep_ros_plugin/package.xml
@@ -22,6 +22,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>pluginlib</build_depend>
+  <build_depend>cmake_modules</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>pluginlib</run_depend>
 


### PR DESCRIPTION
According to Indigo migration guide to give Catkin ability to find e.g. cmake configuration for Eigen, package should have cmake_modules dependency.

All plugins are built and working with those changes.
